### PR TITLE
Upgrade tensorflow to 2.2.0

### DIFF
--- a/docker/data-science/requirements.txt
+++ b/docker/data-science/requirements.txt
@@ -45,7 +45,7 @@ requests==2.22.0
 retrying==1.3.3
 Send2Trash==1.5.0
 six==1.12.0
-tensorflow==2.1.0
+tensorflow==2.2.0
 #terminado==0.8.2
 testpath==0.4.2
 tornado==6.0.3


### PR DESCRIPTION
aips-data-science container fails to build with tensorflow 2.1.0.