### PR TITLE
Docker python3.7

### DIFF
--- a/docker/data-science/Dockerfile
+++ b/docker/data-science/Dockerfile
@@ -1,4 +1,6 @@
-FROM jupyter/scipy-notebook
+# THis tag uses python 3.7, pyspark does not work with python 3.8 except on
+# Spark 3.0 (see https://github.com/apache/spark/pull/26194)
+FROM jupyter/scipy-notebook:619e9cc2fc07
 
 USER root
 

--- a/docker/data-science/requirements.txt
+++ b/docker/data-science/requirements.txt
@@ -45,7 +45,7 @@ requests==2.22.0
 retrying==1.3.3
 Send2Trash==1.5.0
 six==1.12.0
-tensorflow==2.1.0
+tensorflow==2.2.0
 #terminado==0.8.2
 testpath==0.4.2
 tornado==6.0.3


### PR DESCRIPTION
Uses python 3.7, pyspark does not work with python 3.8 except on Spark 3.0 (see https://github.com/apache/spark/pull/26194)
