### PR TITLE
Upgrading to Apache Spark 2.4.6

### DIFF
--- a/docker/data-science/Dockerfile
+++ b/docker/data-science/Dockerfile
@@ -3,7 +3,7 @@ FROM jupyter/scipy-notebook
 USER root
 
 # Spark dependencies
-ENV APACHE_SPARK_VERSION=2.4.5 \
+ENV APACHE_SPARK_VERSION=2.4.6 \
     HADOOP_VERSION=2.7 \
     SPARK_SOLR_VERSION=3.7.3
 


### PR DESCRIPTION
I believe there is an error in the Apache Spark version as 2.4.5 is not listed on https://spark.apache.org/downloads.html.

Error message when trying to run previous code:
```--2020-07-17 14:22:44--  http://mirrors.advancedhosters.com/apache/spark/spark-2.4.5/spark-2.4.5-bin-hadoop2.7.tgz
Resolving mirrors.advancedhosters.com (mirrors.advancedhosters.com)... 213.174.147.249, 2a02:b48:6:1::2
Connecting to mirrors.advancedhosters.com (mirrors.advancedhosters.com)|213.174.147.249|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2020-07-17 14:22:44 ERROR 404: Not Found.