### PR TITLE
Improvements in Dockerfile & bump spaCy version

### DIFF
--- a/docker/data-science/Dockerfile
+++ b/docker/data-science/Dockerfile
@@ -72,14 +72,13 @@ WORKDIR /home/$NB_USER
 
 # Pull Requirements, Install Notebooks
 COPY requirements.txt ./
-RUN python -m pip install --upgrade pip && \
-  pip install -r requirements.txt \
-  --use-feature=2020-resolver
+RUN python -m pip --no-cache-dir install --upgrade pip && \
+  pip --no-cache-dir install -r requirements.txt
 
 RUN python -m spacy download en_core_web_sm
 
 #must be installed after other requirements for now due to spacy/neuralcoref compatability issues
-RUN pip install git+https://github.com/huggingface/neuralcoref.git@654d90659e34f78b98681ccde7bdda4558aa21c2 --no-binary neuralcoref
+RUN pip --no-cache-dir install git+https://github.com/huggingface/neuralcoref.git@654d90659e34f78b98681ccde7bdda4558aa21c2 --no-binary neuralcoref
 
 #RUN git clone https://github.com/ai-powered-search/retrotech.git $WORKDIR/retrotech
 

--- a/docker/data-science/requirements.txt
+++ b/docker/data-science/requirements.txt
@@ -51,7 +51,7 @@ requests==2.22.0
 retrying==1.3.3
 Send2Trash==1.5.0
 six==1.12.0
-spacy==2.3.0
+spacy==2.3.2
 #tensorflow==2.2.0
 #terminado==0.8.2
 testpath==0.4.2


### PR DESCRIPTION
By specifying `--no-cache-dir` for `pip` it was possible to shrink Docker image size by ~100Mb