### PR TITLE
Move copying of notebooks to the later stage so build happens faster

### DIFF
--- a/docker/data-science/Dockerfile
+++ b/docker/data-science/Dockerfile
@@ -15,8 +15,6 @@ RUN mkdir -p /usr/local/spark/lib/ && cd /usr/local/spark/lib/ && \
     echo "c5293f10257603bcf650780afcb91ed1bb118f09feb731502c2dc7ac14ba950e586a033cb2f50e5c122c5ec442dc0d2b55f76c4f6522b555e67f4981a38bca26 *spark-solr-${SPARK_SOLR_VERSION}-shaded.jar" | sha512sum -c - && \
     chmod a+rwx $SHADED_SOLR_JAR_PATH
 
-COPY notebooks notebooks
-
 WORKDIR /home/$NB_USER
 
 # Pull Requirements, Install Notebooks
@@ -30,6 +28,8 @@ RUN python -m spacy download en_core_web_sm
 RUN pip --no-cache-dir install https://github.com/explosion/spacy-experimental/releases/download/v0.6.1/en_coreference_web_trf-3.4.0a2-py3-none-any.whl
 
 COPY log4j.properties /usr/local/spark/conf/
+
+COPY notebooks notebooks
 
 RUN chown -R $NB_UID:$NB_UID /home/$NB_USER
 USER $NB_UID


### PR DESCRIPTION
Right now, when notebooks are modified, the rest of the layers are invalidated so it will require to rebuild all Python packages.  By moving copying to the later point we'll get layers reuse