### PR TITLE
fix spacy model download

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -29,9 +29,12 @@ WORKDIR /home/$NB_USER
 # Install Python dependencies
 COPY build/ch5_spacy_requirements.txt /home/$NB_USER
 RUN conda create --name ch5-spacy python=3.10.0 -y
-RUN conda run --name ch5-spacy pip install -r ch5_spacy_requirements.txt 
-RUN conda run --name ch5-spacy python -m spacy download en_core_web_sm
+RUN conda run --name ch5-spacy pip install -r ch5_spacy_requirements.txt
+# Install spacy model explicitly instead of "spacy download"
+RUN conda run --name ch5-spacy pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
+RUN conda run --name ch5-spacy python -m spacy link en_core_web_sm en_core_web_sm
 RUN conda run --name ch5-spacy python -m ipykernel install --name ch5-spacy --display-name "[ONLY FOR CH5.1] spaCy experimental kernel"
+
 
 ENV BLIS_ARCH="generic" PIP_CACHE_DIR=/var/cache/pip
 RUN mkdir -p $PIP_CACHE_DIR


### PR DESCRIPTION
Hi,

I trued to build the docker image but i had the error:

```
=> ERROR [stage-0 9/28] RUN conda run --name ch5-spacy python -m spacy download en_core_web_sm 2.6s ------ > [stage-0 9/28] RUN conda run --name ch5-spacy python -m spacy download en_core_web_sm: 2.575 /opt/conda/envs/ch5-spacy/lib/python3.10/site-packages/spacy/cli/info.py:3: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81. 2.575 import pkg_resources 2.575 WARNING: The directory '/home/jovyan/.cache/pip' or its parent directory is not owned or is not writable by the current user. The cache has been disabled. Check the permissions and owner of that directory. If executing pip with sudo, you should use sudo's -H flag. 2.575 DEPRECATION: https://github.com/explosion/spacy-models/releases/download/-en_core_web_sm/-en_core_web_sm.tar.gz#egg===en_core_web_sm contains an egg fragment with a non-PEP 508 name. pip 25.3 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at https://github.com/pypa/pip/issues/13157 2.575 ERROR: Invalid requirement: '==en_core_web_sm': Expected package name at the start of dependency specifier 2.575 ==en_core_web_sm 2.575 ^ 2.575 2.575 ERROR conda.cli.main_run:execute(47): conda run python -m spacy download en_core_web_sm failed. (See above for error) ------ Dockerfile:33 -------------------- 31 | RUN conda create --name ch5-spacy python=3.10.0 -y 32 | RUN conda run --name ch5-spacy pip install -r ch5_spacy_requirements.txt 33 | >>> RUN conda run --name ch5-spacy python -m spacy download en_core_web_sm 34 | RUN conda run --name ch5-spacy python -m ipykernel install --name ch5-spacy --display-name "[ONLY FOR CH5.1] spaCy experimental kernel" 35 | -------------------- failed to solve: process "/bin/bash -o pipefail -c conda run --name ch5-spacy python -m spacy download en_core_web_sm" did not complete successfully: exit code: 1
```

I solved it by replacing in `build/Dockerfile` (lines 33):

```
# Install spacy model explicitly instead of "spacy download"
RUN conda run --name ch5-spacy pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
RUN conda run --name ch5-spacy python -m spacy link en_core_web_sm en_core_web_sm
```

I hope the PR is okay.

Issue #219 

