### PR TITLE
Update spacy model pull syntax due to PIP back compat break

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -57,7 +57,7 @@ RUN conda run --name ch5-spacy python -m ipykernel install --name ch5-spacy --di
 COPY build/requirements.txt /home/$NB_USER
 RUN --mount=type=cache,target=$PIP_CACHE_DIR \
     pip install -r requirements.txt && \
-    python -m spacy download en_core_web_sm
+    pip install "en_core_web_sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.5.0/en_core_web_sm-3.5.0-py3-none-any.whl"
 RUN rm course_requirements.txt ch5_spacy_requirements.txt requirements.txt
 
 # Configure home directory


### PR DESCRIPTION
Issues were reported building the main notebooks Docker container due to an inability to pull space model files. It appears to be related to PIP breaking syntax backwards compatibility, so implementing the a suggested workaround that follows the updates syntax standard:

Error:
```
57.86 WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
57.88 WARNING: There was an error checking the latest version of pip.
60.04 DEPRECATION: https://github.com/explosion/spacy-models/releases/download/-en_core_web_sm/-en_core_web_sm.tar.gz#egg===en_core_web_sm contains an egg fragment with a non-PEP 508 name pip 25.0 will enforce this behaviour change. A possible replacement is to use the req @ url syntax, and remove the egg fragment. Discussion can be found at https://github.com/pypa/pip/issues/11617
60.04 ERROR: Invalid requirement: '==en_core_web_sm'
60.05 WARNING: There was an error checking the latest version of pip.
------
[+] up 0/2
 ⠙ Image ai-powered-search-solr      Building                             342.7s
 ⠙ Image ai-powered-search-notebooks Building                             342.7s
target notebooks: failed to solve: process "/bin/bash -o pipefail -c pip install -r requirements.txt &&     python -m spacy download en_core_web_sm" did not complete successfully: exit code: 1
```